### PR TITLE
WIP: Updated dependencies for Laravel 6.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     "require": {
         "php": "^7.1",
         "jeremykendall/php-domain-parser": "^5.4",
-        "illuminate/support": "^5.5",
-        "illuminate/config": "^5.5"
+        "illuminate/support": "^5.5|^6.0",
+        "illuminate/config": "^5.5|^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
         "guzzlehttp/guzzle": "^6.3",
-        "orchestra/testbench": "^3.7",
+        "orchestra/testbench": "^3.7|^4.0",
         "phpstan/phpstan": "^0.10.6",
         "phpstan/phpstan-phpunit": "^0.10.0",
         "phpstan/phpstan-strict-rules": "^0.10.1",


### PR DESCRIPTION
This bumps the version requirements to support Laravel 6.x. Sadly due to the PHPUnit requirements in `laravel/framework` and `orchestra/testbench` this isn't compatible with previous releases of Laravel.

@nyamsprod What are your thoughts about this?