### PR TITLE
fix: use mixins for autocompletion

### DIFF
--- a/src/Facades/DomainParser.php
+++ b/src/Facades/DomainParser.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Bakame\Laravel\Pdp\Facades;
 
+use Bakame\Laravel\Pdp\DomainParser as BaseDomainParser;
 use Illuminate\Support\Facades\Facade;
-use \Bakame\Laravel\Pdp\DomainParser as BaseDomainParser;
 
 /**
  * @mixin BaseDomainParser

--- a/src/Facades/DomainParser.php
+++ b/src/Facades/DomainParser.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Bakame\Laravel\Pdp\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use \Bakame\Laravel\Pdp\DomainParser as BaseDomainParser;
 
+/**
+ * @mixin BaseDomainParser
+ */
 class DomainParser extends Facade
 {
     /**

--- a/src/Facades/Rules.php
+++ b/src/Facades/Rules.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 namespace Bakame\Laravel\Pdp\Facades;
-use Pdp\Rules as RulesContract;
 
 use Illuminate\Support\Facades\Facade;
+use Pdp\Rules as RulesContract;
 
 /** @mixin RulesContract */
 class Rules extends Facade

--- a/src/Facades/Rules.php
+++ b/src/Facades/Rules.php
@@ -3,9 +3,11 @@
 declare(strict_types=1);
 
 namespace Bakame\Laravel\Pdp\Facades;
+use Pdp\Rules as RulesContract;
 
 use Illuminate\Support\Facades\Facade;
 
+/** @mixin RulesContract */
 class Rules extends Facade
 {
     /**

--- a/src/Facades/TopLevelDomains.php
+++ b/src/Facades/TopLevelDomains.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Bakame\Laravel\Pdp\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Pdp\TopLevelDomainList;
 
+/** @mixin TopLevelDomainList */
 class TopLevelDomains extends Facade
 {
     /**


### PR DESCRIPTION
By using mixins, an IDE will know which methods are available in the facade.